### PR TITLE
Improve the GitHub Actions workflow after linting with zizmor and pinning versions with pinact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,21 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.8.12"
+          enable-cache: false
       - name: Install Python
         run: uv python install
       - name: Build package
         run: uv build
-      - name: Publish
+      - name: Publish package to PyPI
         run: uv publish --token ${{ secrets.PYPI_API_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Lint the GitHub Actions workflow with [zizmor](https://github.com/zizmorcore/zizmor) and [pin all actions](https://github.com/suzuki-shunsuke/pinact).
+
 ## [2.1.0] - 2026-02-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -113,6 +113,22 @@ Finally, deactivate the development environment:
 deactivate
 ```
 
+### GitHub Actions
+
+The feedzai-altair-theme is published via [GitHub Actions](https://docs.github.com/en/actions). So, [zizmor](https://github.com/zizmorcore/zizmor) is used to lint workflows and [pinact](https://github.com/suzuki-shunsuke/pinact) to pin versions of actions like `actions/checkout`.
+
+If you change the [`release.yml` file](.github/workflows/release.yml), install [zizmor](https://docs.zizmor.sh/installation/) (if necessary), run the following command, and implement the relevant feedback:
+
+```bash
+zizmor .
+```
+
+To update action versions, install [pinact](https://github.com/suzuki-shunsuke/pinact/blob/main/INSTALL.md) (if necessary) and run the following command:
+
+```bash
+pinact run -u --min-age 7
+```
+
 ## Deployment
 
 ### Bump the package version


### PR DESCRIPTION
Hi! 👋 

This PR updates the GitHub Actions workflow to publish the package following security best practices.

## References

- https://github.com/suzuki-shunsuke/pinact#motivation
- https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions
- https://github.com/evilmartians/oklch-picker
- https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0
- https://github.com/lirantal/pypi-security-best-practices#13-secure-your-cicd-release-pipeline