### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,18 @@
+cff-version: 1.2.0
+title: feedzai-altair-theme
+message: If you use feedzai-altair-theme, please cite it using the metadata from this file.
+type: software
+authors:
+  - name: Feedzai
+    email: oss-licenses@feedzai.com
+repository-code: https://github.com/feedzai/feedzai-altair-theme
+url: https://github.com/feedzai/feedzai-altair-theme
+repository-artifact: https://pypi.org/project/feedzai-altair-theme/
+abstract: Feedzai's theme for Altair charts.
+keywords:
+  - python
+  - data visualization
+  - altair
+  - altair themes
+license-url: https://github.com/feedzai/feedzai-altair-theme/blob/master/LICENSE
+date-released: 2022-06-02

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,9 +10,9 @@ url: https://github.com/feedzai/feedzai-altair-theme
 repository-artifact: https://pypi.org/project/feedzai-altair-theme/
 abstract: Feedzai's theme for Altair charts.
 keywords:
-  - python
-  - data visualization
   - altair
   - altair themes
+  - data visualization
+  - python
 license-url: https://github.com/feedzai/feedzai-altair-theme/blob/master/LICENSE
 date-released: 2022-06-02


### PR DESCRIPTION
Hi! 👋 

This PR adds the `CITATION.cff` file. This file allows the repo to show how to cite this package in articles, for example, making it easier to get the BibTeX snippet.

<img width="1470" height="517" alt="" src="https://github.com/user-attachments/assets/3fe252d2-e2dc-44a0-b050-42c5f8aee5c6" />

## References

- https://citation-file-format.github.io/
- https://citation-file-format.github.io/cff-initializer-javascript/#/
- https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md
- https://github.com/citation-file-format/ruby-cff/blob/main/CITATION.cff
- https://github.com/tiangolo/library-skills/blob/main/CITATION.cff